### PR TITLE
Fixes  blackbunt/dump-discogs-collection-2-csv#7

### DIFF
--- a/DumpDiscogs.py
+++ b/DumpDiscogs.py
@@ -11,6 +11,7 @@ import configparser
 import check_exists as exist
 import urllib.request
 import logging
+import re
 
 # Basic logging to file
 LOG_FILENAME="debug.log"
@@ -100,6 +101,9 @@ while True:
                     discogs_no = str(_db.iloc[item]['discogs_no'])
                     artist = str(_db.iloc[item]['artist'])
                     album_title = str(_db.iloc[item]['album_title'])
+                    # sanitize the title (for example, album names having / in the name)
+                    artist = re.sub(r'[^a-zA-Z0-9]', '_', artist)
+                    album_title = re.sub(r'[^a-zA-Z0-9]', '_', album_title)
 
                     filename = discogs_no + "_" + artist + '-' + album_title + '.jpg'
                     cover_art_url = str(_db.iloc[item]['cover_full_url'])

--- a/module/print.py
+++ b/module/print.py
@@ -20,5 +20,6 @@ def title():
     print("2. Load collection, generate QR codes and write to Excel File")
     print("3. Load collection, generate QR codes and write to Csv File")
     print("4. Load collection and just create QR Codes")
+    print("5. Dump Cover Art")
     print("0. Exit")
     print("")


### PR DESCRIPTION
Proposal for a fix - I hope is clearer from the code :)

Linux refuses to create a file name that has a '/' in its name. So when saving the Cover Art, and if the Artist (or Album Name) have a forward slash in the name ... the code will download the Cover Art, but the will not be able to save it.

In my local fix, I am just removing anything non ASCII and replacing the weird characters with '_'. This way the Cover Art will always be saved on the disk.